### PR TITLE
Frappe/ERPNExt utility apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,8 @@ _Apps that showcase the power of the Frappe Framework_
 - [Chat](https://github.com/frappe/chat) - Modern chat for your Frappe deployments.
 - [Wiki](https://github.com/frappe/wiki) - Wiki for serving dynamic data along with a built-in review system.
 - [Release](https://github.com/frappe/release) - Manage releases for Frappe and Frappe Applications.
-- [Language translator](https://github.com/mymi14s/language_translator) - Automatic language translator on Frappe Desk and website
-- [Database Console](https://github.com/mymi14s/database_console) - Execute SQL queries directly from Frappe/ERPNExt desk just like 'bench mariadb'
-
-
+- [Language Translator](https://github.com/mymi14s/language_translator) - Automatic language translator on Frappe Desk and website.
+- [Database Console](https://github.com/mymi14s/database_console) - Execute SQL queries directly from Frappe/ERPNExt desk just like 'bench mariadb'.
 
 
 #### Integrations
@@ -51,7 +49,7 @@ _Apps that showcase the power of the Frappe Framework_
 - [Razorpay Integration](https://github.com/frappe/razorpay_integration) - Razorpay Integration for Frappe.
 - [Mandrill Integration](https://github.com/frappe/mandrill_integration) - Mandrill Integration for Frappe.
 - [Mautic Integration](https://github.com/dokos-io/mautic) - Mautic Integration for ERPNext.
-- [Paystack Integration](https://github.com/mymi14s/frappe_paystack) - Paystack Payment Gateway Integration for ERPNext/Frappe.
+- [Paystack Integration](https://github.com/mymi14s/frappe_paystack) - Paystack Payment Gateway Integration for Frappe.
 
 
 ### Developer Tooling


### PR DESCRIPTION
Frappe/ERPNext app currently used in production. They are integration and utility apps.

- - [Language translator](https://github.com/mymi14s/language_translator) - Automatic language translator on Frappe Desk and website
- - [Database Console](https://github.com/mymi14s/database_console) - Execute SQL queries directly from Frappe/ERPNExt desk just like 'bench mariadb'
- - [Paystack Integration](https://github.com/mymi14s/frappe_paystack) - Paystack Payment Gateway Integration for ERPNext/Frappe.