### PR TITLE
Add Frappe Web Push to Utility apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ _Apps that showcase the power of the Frappe Framework_
 - [Frappe PWA](https://github.com/Monogramm/frappe_pwa) - PWA setup for Frappe website.
 - [Frappe ReST API Wrapper](https://github.com/pifabs/restipie) - Build custom ReST api's on top of Frappe.
 - [Frappe System Monitor](https://github.com/mymi14s/frappe_system_monitor) - Web interface for webserver running processes and system utilization (RAM, CPU, Disk)
+- [Frappe Web Push](https://github.com/meichthys/frappe_web_push) - Enables native local browser toast notifications without the need for remote servers like firebase or frappe-cloud 
 - [Go1 CMS](https://github.com/TridotsTech/go1cms) - Advanced Content Management System built on Frappe.
 - [In-Context Translation](https://github.com/Mazen-Almortada/incontext_translation) - In-context translation for Frappe & ERPNext with automated suggestions.
 - [Kai](https://github.com/KorucuTech/kai) - Custom Frappe App to integrate AI Agents as DocTypes using CrewAI & Frappe Framework.


### PR DESCRIPTION
Frappe Web push enables native browser toast notifications without the need for cloud services.