### PR TITLE
Add Frappista

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ _Apps that showcase the power of the Frappe Framework_
 - [Renovation](https://github.com/leam-tech/renovation_core) - Renovation is a Frappe Front End TS/JS SDK.
 - [renovation_core.dart](https://github.com/leam-tech/renovation_core.dart) - The Frappe Dart/Flutter Front End SDK.
 
+- [Frappista](https://github.com/vyogotech/frappista) - Pre-baked Frappe/ERPNext images designed for quick trials and simplified development workloads. High-performance, bootable containers that include a pre-configured site for immediate use.
+
 #### Templates
 
 - [App Template](https://github.com/Monogramm/erpnext_template) - @Monogramm's supercharged GitHub template for building ERPNext/Frappe Apps.


### PR DESCRIPTION
Category
Developer Tooling

Sub Category
Developer Tooling

App or Resource URL
https://github.com/vyogotech/frappista

App or Resource Name
Frappista

App or Resource Description
Pre-baked Frappe/ERPNext images designed for quick trials and simplified development workloads. High-performance, bootable containers that include a pre-configured site for immediate use.