### PR TITLE
fix: Make hero counter dynamic and include all categories

### DIFF
--- a/_plugins/readme_parser.rb
+++ b/_plugins/readme_parser.rb
@@ -127,27 +127,16 @@ module Jekyll
     end
 
     def calculate_counts(categories)
-      counts = {
-        'total_items' => 0,
-        'apps' => 0,
-        'developer_tooling' => 0,
-        'other_tooling' => 0,
-        'deployment_tools' => 0,
-        'other_clients' => 0,
-        'resources' => 0,
-        'hosting' => 0
-      }
+      counts = { 'total_items' => 0 }
 
       categories.each do |category|
-        # Count all items in category and subcategories
         category_count = category['items'].length
         category['subcategories'].each do |subcat|
           category_count += subcat['items'].length
         end
 
-        # Map to count keys
         key = slugify(category['name']).gsub('-', '_')
-        counts[key] = category_count if counts.key?(key)
+        counts[key] = category_count
         counts['total_items'] += category_count
       end
 

--- a/index.html
+++ b/index.html
@@ -15,25 +15,9 @@ layout: default
 
       <!-- Right: Stats, Search, TOC -->
       <div class="hero-content">
-        <!-- Calculate Stats -->
-        {% assign total_apps = 0 %}
-        {% assign total_tools = 0 %}
-        {% assign total_resources = 0 %}
-
-        {% for category in site.data.projects %}
-          {% if category.name == "Apps" %}
-            {% for subcategory in category.subcategories %}
-              {% assign total_apps = total_apps | plus: subcategory.items.size %}
-            {% endfor %}
-          {% elsif category.name == "Developer Tooling" or category.name == "Other Tooling" or category.name == "Deployment Tools" %}
-            {% for subcategory in category.subcategories %}
-              {% assign total_tools = total_tools | plus: subcategory.items.size %}
-            {% endfor %}
-            {% assign total_tools = total_tools | plus: category.items.size %}
-          {% elsif category.name == "Resources" %}
-            {% assign total_resources = total_resources | plus: category.items.size %}
-          {% endif %}
-        {% endfor %}
+        {% assign total_apps = site.data.counts.apps | default: 0 %}
+        {% assign total_resources = site.data.counts.resources | default: 0 %}
+        {% assign total_tools = site.data.counts.total_items | minus: total_apps | minus: total_resources %}
 
         <h1 class="hero-title">Find what you're looking for through <strong>{{ total_apps }} apps</strong>, <strong>{{ total_tools }} tools</strong> & <strong>{{ total_resources }} resources</strong> across the frappeverse</h1>
 


### PR DESCRIPTION
## Summary

- Removed hardcoded category whitelist from hero counter in `index.html`
- Made `readme_parser.rb` populate `site.data.counts` for every category dynamically (no pre-seeded keys)
- Hero on `main` will now show **190 apps, 58 tools, 6 resources = 254** (was undercounting by 8: tools showed 50)

## Background

The hero counter in `index.html` only summed Apps, Developer Tooling, "Other Tooling", Deployment Tools, and Resources. That excluded **Hardware & IoT (2)**, **Other Clients (2)**, and **Hosting (4)** — 8 items invisible to the headline. `Other Tooling` was also a dead branch (category no longer exists in the README).

Adding a new category previously required editing both the README and `index.html`'s liquid template. Now it's automatic — the parser stores every category's count under its slug, and the hero derives `total_apps` and `total_resources` directly from `site.data.counts`, then computes `total_tools` as the remainder (`total_items - apps - resources`).

## Known semantic wart

Hosting (4 items) now buckets under "tools" via the remainder math. Slight stretch label-wise; happy to add a dedicated bucket later if you want a separate Hosting count, or rename "tools" → "tools & infra".

## Test plan

- [ ] Build site locally (`bundle exec jekyll build`) and confirm hero reads `190 apps, 58 tools & 6 resources`
- [ ] Confirm no template errors on `site.data.counts` lookups
- [ ] Visual check on deployed Pages preview
