### PR TITLE
Add forge-frappe-skill (AI & MCP Tooling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ _Apps that showcase the power of the Frappe Framework_
 
 #### AI & MCP Tooling
 
+- [forge-frappe-skill](https://github.com/sbknext/forge-frappe-skill) - MIT library of 480+ curated Frappe agent-skills (DocTypes, hooks, Query Builder, permissions, REST/RPC APIs, reports, testing, ops) for AI coding agents — works via any MCP host or standalone markdown. Aggregates and credits public OSS skill sources.
 - [Frappe Assistant Core](https://github.com/buildswithpaul/Frappe_Assistant_Core) - Infrastructure that connects LLMs to ERPNext with Model Context Protocol (MCP).
 - [Frappe MCP Server](https://github.com/appliedrelevance/frappe-mcp-server) - A server that implements the Anthropic Model Control Protocol (MCP) to enable controlled access to Frappe sites.
 - [Frappe MCP](https://github.com/frappe/mcp) - Allows Frappe apps to function as MCP servers.


### PR DESCRIPTION
Adds [forge-frappe-skill](https://github.com/sbknext/forge-frappe-skill) under **Developer Tooling → AI & MCP Tooling**.

It's an MIT, curated library of 480+ Frappe agent-skills (DocTypes, hooks, Query Builder, permissions, REST/RPC APIs, reports, testing, ops) for AI coding agents — usable via any MCP host or standalone markdown. It aggregates and credits public OSS skill sources (Impertio, lubus, official Frappe docs, netchampfaris, vyogotech). Thanks for the awesome list!